### PR TITLE
Add markdown content negotiation for AI agents and web crawlers

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,9 +2,13 @@
 title: The Haha Scale
 tag_text: The Haha Scale
 description: Seriously funny.
+url: https://hahascale.lol
 
 # Build settings
 markdown: kramdown
 exclude: ["README.md"]
 sass:
   style: compressed
+
+# Ensure markdown folder is included in build output
+include: ["markdown"]

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -7,6 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>{{ site.title }}</title>
   <link rel="stylesheet" href="css/main.css">
+  {% if page.markdown_path %}<link rel="alternate" type="text/markdown" href="{{ page.markdown_path }}" title="Markdown version">{% endif %}
 {% include head.html %}
 </head>
 <body>

--- a/index.md
+++ b/index.md
@@ -1,5 +1,6 @@
 ---
 layout: default
+markdown_path: /markdown/index.md
 ---
 
 ### Introduction

--- a/markdown/index.md
+++ b/markdown/index.md
@@ -1,0 +1,51 @@
+<!--
+title: The Haha Scale
+description: A standardized system for communicating humor levels. Stop using lol.
+url: https://hahascale.lol/
+-->
+
+# The Haha Scale
+
+## Introduction
+
+Communicating through text is hard. Apparently, reacting to the things your hilarious friends say is also difficult, because you've invented "words" like `haha`, `lol`, `rofl`, and `lmao` to show when something is funny to you.
+
+On top of the ridiculous words you've invented, it's _still_ impossible to tell when one thing is funnier than another. Is `hahaha` more or less funny than `lol`? Is `😂` stronger than `💀`? More importantly, how many skull emojis does it take before we collectively agree you're being dramatic? Animals.
+
+## Usage
+
+This system is designed to give you and your chronically online friends a uniform way to communicate your reaction to funny stuff. It's pretty simple, but you should probably pay attention.
+
+There are only three rules:
+
+- Humor is measured from `ha1` to `ha10`.
+- A `ha1` may also be expressed as a `ha`.
+- Don't use `lol` ever again.
+
+## Examples
+
+- `ha1` = Someone replies with just "this" to your message.
+- `ha2` = Friend sends you a TikTok that's been on your FYP for weeks.
+- `ha3` = Dad discovers a meme format from 2020 and thinks he's hilarious.
+- `ha4` = Someone sends a Minion meme unironically.
+- `ha5` = Coworker shares a millennial pause video in the group chat.
+- `ha6` = Friend accidentally sends a meme to the family group chat that was meant for the homies.
+- `ha7` = Friend sends perfectly timed SpongeBob meme in response to your life crisis.
+- `ha8` = That friend who quotes Vine/TikTok audio at the perfect moment IRL.
+- `ha9` = That one friend who always finds unhinged Twitter/X threads before they blow up.
+- `ha10` = Someone creates an entire PowerPoint presentation just to roast you in the group chat.
+
+## Summary
+
+At the end of the day, your friends probably aren't as funny as their algorithm-curated content makes them seem, but at least now we can all be on the same page with our reactions to humor. Please stop `lol`ing. We're begging you.
+
+## Downloads
+
+- [iMessage Sticker Pack](https://apps.apple.com/us/app/the-haha-scale-sticker-pack/id1158631658) - Available on the App Store
+- [Custom Slack Emoji](https://hahascale.lol/haha-scale-slack-emoji.zip) - Download and add to your workspace
+
+## Credits
+
+Created by [Jonathan Simmons](https://twitter.com/jonathansimmons) and [Josh Ferrara](https://twitter.com/joshferrara).
+
+© 2016 — 2026 Jonathan Simmons & Josh Ferrara

--- a/markdown/privacy.md
+++ b/markdown/privacy.md
@@ -1,12 +1,13 @@
----
-layout: default
-markdown_path: /markdown/privacy.md
----
+<!--
+title: Privacy Policy - The Haha Scale
+description: Privacy policy for The Haha Scale sticker pack application
+url: https://hahascale.lol/privacy
+last_updated: 2022-09-10
+-->
 
-**Last updated**  
-September 10 2022
+# Privacy Policy
 
-**Privacy Policy**
+**Last updated:** September 10, 2022
 
 Hivemind Labs built the Haha Scale Sticker Pack as a Free app. This SERVICE is provided by Hivemind Labs at no cost and is intended for use as is.
 
@@ -14,12 +15,12 @@ This page is used to inform visitors regarding our policies with the collection,
 
 If you choose to use our Service, then you agree to the collection and use of information in relation to this policy. The Personal Information that we collect is used for providing and improving the Service. We will not use or share your information with anyone except as described in this Privacy Policy.
 
-**Changes to This Privacy Policy**
+## Changes to This Privacy Policy
 
 We may update our Privacy Policy from time to time. Thus, you are advised to review this page periodically for any changes. We will notify you of any changes by posting the new Privacy Policy on this page.
 
-This policy is effective as of 2022-09-10
+This policy is effective as of 2022-09-10.
 
-**Contact Us**
+## Contact Us
 
 If you have any questions or suggestions about our Privacy Policy, do not hesitate to contact us at info@hivemindlabs.com.


### PR DESCRIPTION
- Add rel="alternate" link tags pointing to markdown versions in HTML head
- Create /markdown/ folder with raw markdown versions of pages
- Include metadata (title, description, url) in markdown files for parsing
- Update Jekyll config to ensure markdown folder is included in build
- Enable agents to discover and access clean markdown content

Inspired by https://dri.es/the-third-audience

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables agents and crawlers to discover clean markdown versions of pages.
> 
> - Adds head `rel="alternate"` link to markdown when `page.markdown_path` is set in `default.html`
> - Introduces `/markdown/index.md` and `/markdown/privacy.md` with `title`, `description`, and `url` metadata comments
> - Adds `markdown_path` front matter to `index.md` and `privacy.md`
> - Updates `_config.yml` to set `url` and include the `markdown` directory in the build
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit de8365403a2f6c48da61ca3c7af7ba0eec98a28b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->